### PR TITLE
fix: round float values to ceiling step

### DIFF
--- a/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeature.java
+++ b/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeature.java
@@ -118,7 +118,6 @@ public final class ButtplugClientDeviceFeature {
         if (desc instanceof DeviceFeature.SteppedOutputDescriptor) {
             double steps = ((DeviceFeature.SteppedOutputDescriptor) desc).getValue()[1];
             steps *= value;
-            
             int result;
             if (steps >= 0) {
                 result = (int) Math.ceil(steps);

--- a/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeature.java
+++ b/buttplug4j/src/main/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeature.java
@@ -118,7 +118,14 @@ public final class ButtplugClientDeviceFeature {
         if (desc instanceof DeviceFeature.SteppedOutputDescriptor) {
             double steps = ((DeviceFeature.SteppedOutputDescriptor) desc).getValue()[1];
             steps *= value;
-            return (int) Math.floor(steps);
+            
+            int result;
+            if (steps >= 0) {
+                result = (int) Math.ceil(steps);
+            } else {
+                result = (int) Math.floor(steps);
+            }
+            return result;
         } else {
             throw new ButtplugDeviceFeatureException(type);
         }

--- a/buttplug4j/src/test/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeatureTest.java
+++ b/buttplug4j/src/test/java/io/github/blackspherefollower/buttplug4j/client/ButtplugClientDeviceFeatureTest.java
@@ -276,7 +276,7 @@ class ButtplugClientDeviceFeatureTest {
         ArgumentCaptor<OutputCmd.IOutputCommand> captor = ArgumentCaptor.forClass(OutputCmd.IOutputCommand.class);
         verify(mockDevice).runOutput(eq(0), captor.capture());
         assertInstanceOf(OutputCmd.Spray.class, captor.getValue());
-        assertEquals(3, ((OutputCmd.Spray) captor.getValue()).getValue());
+        assertEquals(4, ((OutputCmd.Spray) captor.getValue()).getValue());
     }
 
     @Test
@@ -304,7 +304,7 @@ class ButtplugClientDeviceFeatureTest {
         ArgumentCaptor<OutputCmd.IOutputCommand> captor = ArgumentCaptor.forClass(OutputCmd.IOutputCommand.class);
         verify(mockDevice).runOutput(eq(0), captor.capture());
         assertInstanceOf(OutputCmd.Position.class, captor.getValue());
-        assertEquals(20, ((OutputCmd.Position) captor.getValue()).getValue());
+        assertEquals(21, ((OutputCmd.Position) captor.getValue()).getValue());
     }
 
     @Test
@@ -341,7 +341,7 @@ class ButtplugClientDeviceFeatureTest {
         ArgumentCaptor<OutputCmd.IOutputCommand> captor = ArgumentCaptor.forClass(OutputCmd.IOutputCommand.class);
         verify(mockDevice).runOutput(eq(0), captor.capture());
         assertInstanceOf(OutputCmd.HwPositionWithDuration.class, captor.getValue());
-        assertEquals(20, ((OutputCmd.HwPositionWithDuration) captor.getValue()).getValue());
+        assertEquals(21, ((OutputCmd.HwPositionWithDuration) captor.getValue()).getValue());
         assertEquals(500, ((OutputCmd.HwPositionWithDuration) captor.getValue()).getDuration());
     }
 
@@ -370,7 +370,7 @@ class ButtplugClientDeviceFeatureTest {
         ArgumentCaptor<OutputCmd.IOutputCommand> captor = ArgumentCaptor.forClass(OutputCmd.IOutputCommand.class);
         verify(mockDevice).runOutput(eq(0), captor.capture());
         assertInstanceOf(OutputCmd.Led.class, captor.getValue());
-        assertEquals(127, ((OutputCmd.Led) captor.getValue()).getValue());
+        assertEquals(128, ((OutputCmd.Led) captor.getValue()).getValue());
     }
 
     @Test


### PR DESCRIPTION
Changing the rounding behavior when picking an output step from a float value to work the same way as the server.

I don't know how the rounding is done for negative values on the server but I feel like for negative values it's better to use floor rounding.